### PR TITLE
[PKG-2217] sqlparse 0.4.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,18 @@
-{% set version = "0.4.3" %}
+{% set name = "sqlparse" %}
+{% set version = "0.4.4" %}
 
 package:
-  name: sqlparse
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/s/sqlparse/sqlparse-{{ version }}.tar.gz
-  sha256: 69ca804846bb114d2ec380e4360a8a340db83f0ccf3afceeb1404df028f57268
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: d446183e84b8349fa3061f0fe7f06ca94ba65b426946ffebe6e3e8295332420c
 
 build:
   number: 0
   skip: true  # [py<35]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - sqlformat = sqlparse.__main__:main
 
@@ -19,18 +20,18 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
-    - wheel
+    - flit-core >=3.2,<4
   run:
     - python
 
 test:
+  imports:
+    - sqlparse
   requires:
     - pip
   commands:
     - pip check
-  imports:
-    - sqlparse
+    - sqlformat --help
 
 about:
   home: https://github.com/andialbrecht/sqlparse


### PR DESCRIPTION
Changelog: https://github.com/andialbrecht/sqlparse/blob/0.4.4/CHANGELOG
License: https://github.com/andialbrecht/sqlparse/blob/0.4.4/LICENSE
Requirements: https://github.com/andialbrecht/sqlparse/blob/0.4.4/pyproject.toml

Actions:
1. Clean up and improve the recipe:
- Add jinja2 variable `name`
- Add the flag `--no-build-isolation` to `script`
- Remove `setuptools` and `wheel` from `host` as `flit-core` has its own wheel builder https://github.com/pypa/flit/blob/f7496a50debdfa393e39f8e51d328deabcd7ae7e/flit_core/flit_core/wheel.py#L61. So we can ignore the linter warning
2. Add `sqlformat --help` to test/commands as we have `entry_points` in the recipe

Notes:
- We update the package because `sqlparse` **<0.4.4** is affected by CVE-2023-30608 with a score of **7.5**